### PR TITLE
chore: adding mocked S3 bucket for local filestore

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,9 @@ SERVER_PORT=8001
 
 # you want to use gcp or local filesystem
 # gcp -> google cloud storage, local -> local filesystem
+# defaults to gcp
 STORAGE_TYPE=local
 
-# if storage type is gcp, then uncomment below and add the bucket name
+# if storage type is gcp/not set, then uncomment below and add the bucket name
+# defaults to "athene-diagram-files"
 # STORAGE_GCP_BUCKET_NAME=athene-diagram-files

--- a/.env
+++ b/.env
@@ -1,0 +1,9 @@
+# port you want the server to use, defaults to 8080
+SERVER_PORT=8001
+
+# you want to use gcp or local filesystem
+# gcp -> google cloud storage, local -> local filesystem
+STORAGE_TYPE=local
+
+# if storage type is gcp, then uncomment below and add the bucket name
+# STORAGE_GCP_BUCKET_NAME=athene-diagram-files

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules
 
 # Output files
 dist
+
+# local filestore
+localFileStore

--- a/fileStore.ts
+++ b/fileStore.ts
@@ -1,0 +1,47 @@
+
+import EventEmitter from 'node:events';
+import * as fs from 'node:fs';
+
+export default (() => {
+    const base = './localFileStore/'
+    const metaPath = `${base}_meta.json`
+    if (fs.existsSync(base) === false) {
+        fs.mkdirSync(base)
+    }
+    if (fs.existsSync(metaPath) === false) {
+        fs.writeFileSync(metaPath, JSON.stringify({}))
+    }
+    return {
+        file: (filePath: string) => {
+            const fullPath = `${base}${filePath}`
+            return {
+                exists: () => {
+                    return [fs.existsSync(fullPath)]
+                },
+                download: async () => {
+                    return [new Uint8Array(fs.readFileSync(fullPath))]
+                },
+                createWriteStream: () => {
+                    return fs.createWriteStream(fullPath)
+                },
+                createReadStream: () => {
+                    return fs.createReadStream(fullPath)
+                },
+                save: (fileContent: string, meta?: undefined | any) => {
+                    if (typeof meta === 'object') {
+                        const rawMeta = fs.readFileSync(metaPath);
+                        const _meta = JSON.parse(rawMeta.toString())
+                        _meta[fullPath] = meta.metadata
+                        fs.writeFileSync(metaPath, JSON.stringify(_meta))
+                    }
+                    fs.writeFileSync(fullPath, fileContent)
+                },
+                getMetadata: () => {
+                    const rawMeta = fs.readFileSync(metaPath);
+                    const _meta = JSON.parse(rawMeta.toString())
+                    return [_meta[fullPath]]
+                }
+            }
+        }
+    }
+})();

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config'
 import { Database } from '@hocuspocus/extension-database';
 import { Logger } from '@hocuspocus/extension-logger';
 import { Server } from '@hocuspocus/server';
@@ -13,9 +14,9 @@ const uid = new ShortUniqueId({ length: 20 });
 
 const serverPort = parseInt(process.env.SERVER_PORT || '8080');
 let storageBucket: Bucket | typeof fileStore;
-if (process.env.BUCKET_NAME) {
+if (process.env.STORAGE_TYPE === "gcp") {
     const storageClient = new Storage();
-    storageBucket = storageClient.bucket(process.env.BUCKET_NAME);
+    storageBucket = storageClient.bucket(process.env.STORAGE_GCP_BUCKET_NAME || 'athene-diagram-files');
 } else {
     storageBucket = fileStore
 }

--- a/index.ts
+++ b/index.ts
@@ -1,18 +1,24 @@
 import { Database } from '@hocuspocus/extension-database';
 import { Logger } from '@hocuspocus/extension-logger';
 import { Server } from '@hocuspocus/server';
-import { Storage } from '@google-cloud/storage';
+import { Bucket, Storage } from '@google-cloud/storage';
 import { utils } from './stream-helper'
 import cors from 'cors';
 import express from 'express';
 import expressWebsockets from 'express-ws';
 import ShortUniqueId from 'short-unique-id';
+import fileStore from './fileStore';
 
 const uid = new ShortUniqueId({ length: 20 });
 
 const serverPort = parseInt(process.env.SERVER_PORT || '8080');
-const storageClient = new Storage();
-const storageBucket = storageClient.bucket(process.env.BUCKET_NAME || 'athene-diagram-files');
+let storageBucket: Bucket | typeof fileStore;
+if (process.env.BUCKET_NAME) {
+    const storageClient = new Storage();
+    storageBucket = storageClient.bucket(process.env.BUCKET_NAME);
+} else {
+    storageBucket = fileStore
+}
 
 const server = Server.configure({
     extensions: [

--- a/index.ts
+++ b/index.ts
@@ -11,14 +11,14 @@ import ShortUniqueId from 'short-unique-id';
 import fileStore from './fileStore';
 
 const uid = new ShortUniqueId({ length: 20 });
-
 const serverPort = parseInt(process.env.SERVER_PORT || '8080');
+
 let storageBucket: Bucket | typeof fileStore;
-if (process.env.STORAGE_TYPE === "gcp") {
+if (process.env.STORAGE_TYPE === "local") {
+    storageBucket = fileStore
+} else {
     const storageClient = new Storage();
     storageBucket = storageClient.bucket(process.env.STORAGE_GCP_BUCKET_NAME || 'athene-diagram-files');
-} else {
-    storageBucket = fileStore
 }
 
 const server = Server.configure({

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@hocuspocus/provider": "^2.7.1",
         "@hocuspocus/server": "^2.7.1",
         "cors": "^2.8.5",
+        "dotenv": "^16.4.5",
         "express": "^4.18.2",
         "express-ws": "^5.0.2",
         "short-unique-id": "^5.0.3",
@@ -763,6 +764,17 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/duplexify": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@hocuspocus/provider": "^2.7.1",
     "@hocuspocus/server": "^2.7.1",
     "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
     "express": "^4.18.2",
     "express-ws": "^5.0.2",
     "short-unique-id": "^5.0.3",


### PR DESCRIPTION
Wrote a very basic mocking for S3 bucket operations to local file system using fs. When running the docker container we can pass in a persist volume and have it map internally to `localFileStore` so that our data remains persisted even if docker containers are destroyed and rebuild.

Links to this issue - https://github.com/mydraft-cc/ui/issues/234

Routes checked
- [x] GET /:tokenRead
- [x] POST /
- [x] PUT /:tokenRead/:tokenWrite
- [x] GET /health
- [ ] Web Socket /collaboration [not sure how to check this]