### PR TITLE
chore: fixing express static's weird behaviour when trying to serve index.html

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -122,6 +122,6 @@ app.put('/api/:tokenRead/:tokenWrite', async (request, response) => {
     return response.status(201).json({ readToken: tokenRead, writeToken: tokenWrite });
 });
 
-app.use("/*", express.static(path.join(__dirname, './ui/dist')))
+app.use('/*', express.static(path.join(__dirname, './ui/dist'), {}))
 
-app.listen(serverPort, () => console.log(`Listening on http://127.0.0.1:${serverPort}`));
+app.listen(Number(serverPort), '0.0.0.0', () => console.log(`Listening on http://127.0.0.1:${serverPort}`));

--- a/index.ts
+++ b/index.ts
@@ -123,7 +123,7 @@ app.put('/api/:tokenRead/:tokenWrite', async (request, response) => {
 });
 
 app.use(express.static(path.join(__dirname, './ui/dist'), {}))
-app.get('/', function(req, res) {
+app.get('/*', function(req, res) {
     res.sendFile(path.join(__dirname, './ui/dist/index.html'));
 });
 

--- a/index.ts
+++ b/index.ts
@@ -122,6 +122,9 @@ app.put('/api/:tokenRead/:tokenWrite', async (request, response) => {
     return response.status(201).json({ readToken: tokenRead, writeToken: tokenWrite });
 });
 
-app.use('/*', express.static(path.join(__dirname, './ui/dist'), {}))
+app.use(express.static(path.join(__dirname, './ui/dist'), {}))
+app.get('/', function(req, res) {
+    res.sendFile(path.join(__dirname, './ui/dist/index.html'));
+});
 
-app.listen(Number(serverPort), '0.0.0.0', () => console.log(`Listening on http://127.0.0.1:${serverPort}`));
+app.listen(Number(serverPort), () => console.log(`Listening on http://127.0.0.1:${serverPort}`));

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "dev": "nodemon -e ts,js,html index.ts",
+    "dev": "nodemon index.ts",
     "build": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "dev": "nodemon index.ts",
+    "dev": "nodemon -e ts,js,html index.ts",
     "build": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
In some scenario, when we try to access static site using domain name, express static was serving the text/html base index file instead of js bundles forcing NS_ERROR_CONTENT_CORRUPT error on browsers. It would work properly if accessing it through 127.0.0.1. Serving the base index file in a separate route fixed this behaviour.

Relates to https://github.com/mydraft-cc/ui/issues/234